### PR TITLE
Add redcarpet gem to enable GFM syntax

### DIFF
--- a/stepper_motor.gemspec
+++ b/stepper_motor.gemspec
@@ -42,4 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "standard", "1.28.5" # Needed for 2.6
   spec.add_development_dependency "yard"
+  # redcarpet is needed for the yard gem to enable Github Flavored Markdown
+  spec.add_development_dependency "redcarpet"
 end


### PR DESCRIPTION
YARD uses Github Flavored Markdown by default if you have `redcarpet` gem present.


> Due to the growing popularity of Github-Flavoured-Markdown (GFM), YARD now uses the Redcarpet library as the default Markdown formatting library with GFM fenced code blocks enabled. This means that you can use fenced code blocks inside of Markdown files with redcarpet installed without any extra code. Previously, users who wanted GFM in their Markdown would have to specify -m markdown -M redcarpet, but this is now the default behaviour for YARD.


From here https://rubydoc.info/gems/yard/file/docs/WhatsNew.md#What_s_New_in_0_7_x