### PR TITLE
Add new iteration of the PerformStepJob

### DIFF
--- a/lib/stepper_motor.rb
+++ b/lib/stepper_motor.rb
@@ -13,6 +13,7 @@ module StepperMotor
   autoload :Journey, File.dirname(__FILE__) + "/stepper_motor/journey.rb"
   autoload :Step, File.dirname(__FILE__) + "/stepper_motor/step.rb"
   autoload :PerformStepJob, File.dirname(__FILE__) + "/stepper_motor/perform_step_job.rb"
+  autoload :PerformStepJobV2, File.dirname(__FILE__) + "/stepper_motor/perform_step_job_v2.rb"
   autoload :InstallGenerator, File.dirname(__FILE__) + "/generators/install_generator.rb"
   autoload :ForwardScheduler, File.dirname(__FILE__) + "/stepper_motor/forward_scheduler.rb"
   autoload :CyclicScheduler, File.dirname(__FILE__) + "/stepper_motor/cyclic_scheduler.rb"

--- a/lib/stepper_motor/forward_scheduler.rb
+++ b/lib/stepper_motor/forward_scheduler.rb
@@ -13,6 +13,8 @@
 # this scheduler is not a good fit for you, and you will need to use the {CyclicScheduler} instead.
 class StepperMotor::ForwardScheduler
   def schedule(journey)
-    StepperMotor::PerformStepJob.set(wait_until: journey.next_step_to_be_performed_at).perform_later(journey.to_global_id.to_s)
+    StepperMotor::PerformStepJobV2
+      .set(wait_until: journey.next_step_to_be_performed_at)
+      .perform_later(journey_id: journey.id, journey_class_name: journey.class.to_s)
   end
 end

--- a/lib/stepper_motor/perform_step_job_v2.rb
+++ b/lib/stepper_motor/perform_step_job_v2.rb
@@ -1,0 +1,10 @@
+require "active_job"
+
+class StepperMotor::PerformStepJobV2 < ActiveJob::Base
+  def perform(journey_id:, journey_class_name:, **)
+    journey = StepperMotor::Journey.find(journey_id)
+    journey.perform_next_step!
+  rescue ActiveRecord::RecordNotFound
+    return # The journey has been canceled and destroyed previously or elsewhere
+  end
+end


### PR DESCRIPTION
We want to have the journey class in the job arguments, and we don't strictly need GlobalID. We can resolve the actual Journey from the base class alone, simply using `find()`.