### PR TITLE
Allow "def step" and blockless step()

### DIFF
--- a/lib/stepper_motor/journey.rb
+++ b/lib/stepper_motor/journey.rb
@@ -187,7 +187,7 @@ module StepperMotor
       logger.debug { "entering step #{current_step_name}" }
 
       catch(:abort_step) do
-        instance_exec(&@current_step_definition)
+        @current_step_definition.perform_in_context_of(self)
       end
 
       # By the end of the step the Journey must either be untouched or saved

--- a/lib/stepper_motor/step.rb
+++ b/lib/stepper_motor/step.rb
@@ -12,8 +12,15 @@ class StepperMotor::Step
     @seq = seq
   end
 
-  # Makes the Step object itself callable
-  def to_proc
-    @step_block
+  def perform_in_context_of(journey)
+    if @step_block
+      journey.instance_exec(&@step_block)
+    elsif journey.respond_to?(name)
+      journey.public_send(name) # TODO: context/params?
+    else
+      raise NoMethodError.new(<<~MSG, name, _args = nil, _private = false, receiver: journey)
+        No block or method to use for step `#{name}' on #{journey.class}
+      MSG
+    end
   end
 end

--- a/rbi/stepper_motor.rbi
+++ b/rbi/stepper_motor.rbi
@@ -30,10 +30,10 @@ module StepperMotor
     end
     def initialize(name:, seq:, wait: 0, &step_block); end
 
+    # sord omit - no YARD type given for "journey", using untyped
     # sord omit - no YARD return type given, using untyped
-    # Makes the Step object itself callable
-    sig { returns(T.untyped) }
-    def to_proc; end
+    sig { params(journey: T.untyped).returns(T.untyped) }
+    def perform_in_context_of(journey); end
 
     # sord omit - no YARD type given for :name, using untyped
     # Returns the value of attribute name.

--- a/sig/stepper_motor.rbs
+++ b/sig/stepper_motor.rbs
@@ -21,9 +21,9 @@ module StepperMotor
     # sord omit - no YARD type given for "wait:", using untyped
     def initialize: (name: untyped, seq: untyped, ?wait: untyped) -> void
 
+    # sord omit - no YARD type given for "journey", using untyped
     # sord omit - no YARD return type given, using untyped
-    # Makes the Step object itself callable
-    def to_proc: () -> untyped
+    def perform_in_context_of: (untyped journey) -> untyped
 
     # sord omit - no YARD type given for :name, using untyped
     # Returns the value of attribute name.

--- a/test/stepper_motor/journey/step_definition_test.rb
+++ b/test/stepper_motor/journey/step_definition_test.rb
@@ -5,6 +5,47 @@ require "test_helper"
 class StepDefinitionTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
+  test "adds steps to step_definitions" do
+    journey_class = create_journey_subclass do
+      step :one do
+        # noop
+      end
+      step :two, wait: 20.minutes do
+        # noop
+      end
+    end
+
+    assert_kind_of Array, journey_class.step_definitions
+    assert_equal 2, journey_class.step_definitions.length
+
+    step_one, step_two = *journey_class.step_definitions
+
+    assert_equal "one", step_one.name
+    assert_equal 0, step_one.wait
+
+    assert_equal "two", step_two.name
+    assert_equal 20.minutes, step_two.wait
+  end
+
+  test "gives automatic names to anonymous steps" do
+    journey_class = create_journey_subclass do
+      step :one do
+        # noop
+      end
+      step wait: 20.minutes do
+        # noop
+      end
+    end
+
+    assert_kind_of Array, journey_class.step_definitions
+    assert_equal 2, journey_class.step_definitions.length
+
+    step_one, step_two = *journey_class.step_definitions
+
+    assert_equal "one", step_one.name
+    assert_equal "step_2", step_two.name
+  end
+
   test "does not allow invalid values for after: and wait:" do
     assert_raises(ArgumentError) do
       create_journey_subclass do


### PR DESCRIPTION
Allow steps to be defined using method names on the Journey:

```ruby
class ReminderJourney < StepperMotor::Journey
  step :notify_initial
  step :notify_second

  def notify_initial
    # Do things
  end

  def notify_second
    # Do more things
  end
end
```

Closes https://github.com/stepper-motor/stepper_motor/issues/20