### PR TITLE
Remove :concurrently from migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.10] - 2025-05-28
+
+- Remove `algorithm: :concurrently` from migrations. If a user needs to conform with strong_migrations
+  they can always edit the migration themselves.
+
 ## [0.1.9] - 2025-05-25
 
 - Repair bodged migration from the previous release

--- a/lib/generators/stepper_motor_migration_004.rb.erb
+++ b/lib/generators/stepper_motor_migration_004.rb.erb
@@ -7,7 +7,7 @@ class StepperMotorMigration004 < ActiveRecord::Migration[<%= migration_version %
               name: :idx_journeys_one_per_hero_with_paused
 
     # Remove old indexes that only include 'ready' state
-    remove_index :stepper_motor_journeys, [:type, :hero_id, :hero_type], name: :one_per_hero_index, where: "allow_multiple = '0' AND state IN ('ready', 'performing')", algorithm: :concurrently 
+    remove_index :stepper_motor_journeys, [:type, :hero_id, :hero_type], name: :one_per_hero_index, where: "allow_multiple = '0' AND state IN ('ready', 'performing')" 
   end
 
   def down
@@ -19,6 +19,6 @@ class StepperMotorMigration004 < ActiveRecord::Migration[<%= migration_version %
               name: :one_per_hero_index
 
     # Remove new indexes
-    remove_index :stepper_motor_journeys, name: :idx_journeys_one_per_hero_with_paused, algorithm: :concurrently
+    remove_index :stepper_motor_journeys, name: :idx_journeys_one_per_hero_with_paused
   end
 end

--- a/lib/stepper_motor/version.rb
+++ b/lib/stepper_motor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StepperMotor
-  VERSION = "0.1.9"
+  VERSION = "0.1.10"
 end

--- a/rbi/stepper_motor.rbi
+++ b/rbi/stepper_motor.rbi
@@ -2,7 +2,7 @@
 # StepperMotor is a module for building multi-step flows where steps are sequential and only
 # ever progress forward. The building block of StepperMotor is StepperMotor::Journey
 module StepperMotor
-  VERSION = T.let("0.1.9", T.untyped)
+  VERSION = T.let("0.1.10", T.untyped)
 
   class Error < StandardError
   end

--- a/test/dummy/db/migrate/20250528141038_stepper_motor_migration_004.rb
+++ b/test/dummy/db/migrate/20250528141038_stepper_motor_migration_004.rb
@@ -7,7 +7,7 @@ class StepperMotorMigration004 < ActiveRecord::Migration[7.2]
               name: :idx_journeys_one_per_hero_with_paused
 
     # Remove old indexes that only include 'ready' state
-    remove_index :stepper_motor_journeys, [:type, :hero_id, :hero_type], name: :one_per_hero_index, where: "allow_multiple = '0' AND state IN ('ready', 'performing')", algorithm: :concurrently 
+    remove_index :stepper_motor_journeys, [:type, :hero_id, :hero_type], name: :one_per_hero_index, where: "allow_multiple = '0' AND state IN ('ready', 'performing')" 
   end
 
   def down
@@ -19,6 +19,6 @@ class StepperMotorMigration004 < ActiveRecord::Migration[7.2]
               name: :one_per_hero_index
 
     # Remove new indexes
-    remove_index :stepper_motor_journeys, name: :idx_journeys_one_per_hero_with_paused, algorithm: :concurrently
+    remove_index :stepper_motor_journeys, name: :idx_journeys_one_per_hero_with_paused
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_25_132526) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_28_141038) do
   create_table "stepper_motor_journeys", force: :cascade do |t|
     t.string "type", null: false
     t.string "state", default: "ready"


### PR DESCRIPTION
Closes #28

To recreate the migrations, run `bin/rails g stepper_motor:install --force`