### PR TITLE
Allow extending all StepperMotor jobs

### DIFF
--- a/lib/stepper_motor.rb
+++ b/lib/stepper_motor.rb
@@ -14,6 +14,7 @@ module StepperMotor
   autoload :Journey, File.dirname(__FILE__) + "/stepper_motor/journey.rb"
   autoload :Step, File.dirname(__FILE__) + "/stepper_motor/step.rb"
 
+  autoload :BaseJob, File.dirname(__FILE__) + "/stepper_motor/base_job.rb"
   autoload :PerformStepJob, File.dirname(__FILE__) + "/stepper_motor/perform_step_job.rb"
   autoload :PerformStepJobV2, File.dirname(__FILE__) + "/stepper_motor/perform_step_job.rb"
   autoload :HousekeepingJob, File.dirname(__FILE__) + "/stepper_motor/housekeeping_job.rb"

--- a/lib/stepper_motor.rb
+++ b/lib/stepper_motor.rb
@@ -29,4 +29,9 @@ module StepperMotor
 
   mattr_accessor :scheduler, default: ForwardScheduler.new
   mattr_accessor :delete_completed_journeys_after, default: 30.days
+
+  # Extends the BaseJob of the library with any additional options
+  def self.extend_base_job(&blk)
+    BaseJob.class_eval(&blk)
+  end
 end

--- a/lib/stepper_motor/base_job.rb
+++ b/lib/stepper_motor/base_job.rb
@@ -1,2 +1,5 @@
+# All StepperMotor job classes inherit from this one. It is available for
+# extension from StepperMotor.extend_base_job_class so that you can set
+# priority, include and prepend modules and so forth.
 class StepperMotor::BaseJob < ActiveJob::Base
 end

--- a/lib/stepper_motor/base_job.rb
+++ b/lib/stepper_motor/base_job.rb
@@ -1,0 +1,2 @@
+class StepperMotor::BaseJob < ActiveJob::Base
+end

--- a/lib/stepper_motor/cyclic_scheduler.rb
+++ b/lib/stepper_motor/cyclic_scheduler.rb
@@ -21,7 +21,7 @@
 #
 # The scheduler needs to be configured in your cron table.
 class StepperMotor::CyclicScheduler < StepperMotor::ForwardScheduler
-  class RunSchedulingCycleJob < ActiveJob::Base
+  class RunSchedulingCycleJob < StepperMotor::BaseJob
     def perform
       scheduler = StepperMotor.scheduler
       return unless scheduler.is_a?(StepperMotor::CyclicScheduler)

--- a/lib/stepper_motor/delete_completed_journeys_job.rb
+++ b/lib/stepper_motor/delete_completed_journeys_job.rb
@@ -2,7 +2,7 @@
 
 # The purpose of this job is to find journeys which have completed (finished or canceled) some
 # time ago and to delete them. The time is configured in the initializer.
-class StepperMotor::DeleteCompletedJourneysJob < ActiveJob::Base
+class StepperMotor::DeleteCompletedJourneysJob < StepperMotor::BaseJob
   def perform(completed_for: StepperMotor.delete_completed_journeys_after, **)
     return unless completed_for.present?
 

--- a/lib/stepper_motor/housekeeping_job.rb
+++ b/lib/stepper_motor/housekeeping_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class StepperMotor::HousekeepingJob < ActiveJob::Base
+class StepperMotor::HousekeepingJob < StepperMotor::BaseJob
   def perform(**)
     StepperMotor::RecoverStuckJourneysJob.perform_later
     StepperMotor::DeleteCompletedJourneysJob.perform_later

--- a/lib/stepper_motor/perform_step_job.rb
+++ b/lib/stepper_motor/perform_step_job.rb
@@ -2,7 +2,7 @@
 
 require "active_job"
 
-class StepperMotor::PerformStepJob < ActiveJob::Base
+class StepperMotor::PerformStepJob < StepperMotor::BaseJob
   def perform(*posargs, **kwargs)
     if posargs.length == 1 && kwargs.empty?
       perform_via_journey_gid(*posargs)

--- a/lib/stepper_motor/recover_stuck_journeys_job.rb
+++ b/lib/stepper_motor/recover_stuck_journeys_job.rb
@@ -4,7 +4,7 @@
 # `performing` state for far longer than the journey is supposed to. At the moment it assumes
 # any journey that stayed in `performing` for longer than 1 hour has hung. Add this job to your
 # cron table and perform it regularly.
-class StepperMotor::RecoverStuckJourneysJob < ActiveJob::Base
+class StepperMotor::RecoverStuckJourneysJob < StepperMotor::BaseJob
   DEFAULT_STUCK_FOR = 2.days
 
   def perform(stuck_for: DEFAULT_STUCK_FOR)

--- a/rbi/stepper_motor.rbi
+++ b/rbi/stepper_motor.rbi
@@ -306,6 +306,9 @@ module StepperMotor
   class Railtie < Rails::Railtie
   end
 
+  class BaseJob < ActiveJob::Base
+  end
+
   module TestHelper
     # Allows running a given Journey to completion, skipping across the waiting periods.
     # This is useful to evaluate all side effects of a Journey. The helper will ensure
@@ -399,20 +402,20 @@ MSG
     sig { params(journey: T.untyped).returns(T.untyped) }
     def schedule(journey); end
 
-    class RunSchedulingCycleJob < ActiveJob::Base
+    class RunSchedulingCycleJob < StepperMotor::BaseJob
       # sord omit - no YARD return type given, using untyped
       sig { returns(T.untyped) }
       def perform; end
     end
   end
 
-  class HousekeepingJob < ActiveJob::Base
+  class HousekeepingJob < StepperMotor::BaseJob
     # sord omit - no YARD return type given, using untyped
     sig { returns(T.untyped) }
     def perform; end
   end
 
-  class PerformStepJob < ActiveJob::Base
+  class PerformStepJob < StepperMotor::BaseJob
     # sord omit - no YARD type given for "*posargs", using untyped
     # sord omit - no YARD type given for "**kwargs", using untyped
     # sord omit - no YARD return type given, using untyped
@@ -460,7 +463,7 @@ MSG
   # `performing` state for far longer than the journey is supposed to. At the moment it assumes
   # any journey that stayed in `performing` for longer than 1 hour has hung. Add this job to your
   # cron table and perform it regularly.
-  class RecoverStuckJourneysJob < ActiveJob::Base
+  class RecoverStuckJourneysJob < StepperMotor::BaseJob
     DEFAULT_STUCK_FOR = T.let(2.days, T.untyped)
 
     # sord omit - no YARD type given for "stuck_for:", using untyped
@@ -471,7 +474,7 @@ MSG
 
   # The purpose of this job is to find journeys which have completed (finished or canceled) some
   # time ago and to delete them. The time is configured in the initializer.
-  class DeleteCompletedJourneysJob < ActiveJob::Base
+  class DeleteCompletedJourneysJob < StepperMotor::BaseJob
     # sord omit - no YARD type given for "completed_for:", using untyped
     # sord omit - no YARD return type given, using untyped
     sig { params(completed_for: T.untyped).returns(T.untyped) }

--- a/rbi/stepper_motor.rbi
+++ b/rbi/stepper_motor.rbi
@@ -6,6 +6,11 @@ module StepperMotor
   PerformStepJobV2 = T.let(StepperMotor::PerformStepJob, T.untyped)
   RecoverStuckJourneysJobV1 = T.let(StepperMotor::RecoverStuckJourneysJob, T.untyped)
 
+  # sord omit - no YARD return type given, using untyped
+  # Extends the BaseJob of the library with any additional options
+  sig { params(blk: T.untyped).returns(T.untyped) }
+  def self.extend_base_job(&blk); end
+
   class Error < StandardError
   end
 

--- a/sig/stepper_motor.rbs
+++ b/sig/stepper_motor.rbs
@@ -5,6 +5,10 @@ module StepperMotor
   PerformStepJobV2: untyped
   RecoverStuckJourneysJobV1: untyped
 
+  # sord omit - no YARD return type given, using untyped
+  # Extends the BaseJob of the library with any additional options
+  def self.extend_base_job: () -> untyped
+
   class Error < StandardError
   end
 

--- a/sig/stepper_motor.rbs
+++ b/sig/stepper_motor.rbs
@@ -271,6 +271,9 @@ module StepperMotor
   class Railtie < Rails::Railtie
   end
 
+  class BaseJob < ActiveJob::Base
+  end
+
   module TestHelper
     # Allows running a given Journey to completion, skipping across the waiting periods.
     # This is useful to evaluate all side effects of a Journey. The helper will ensure
@@ -352,18 +355,18 @@ module StepperMotor
     # sord omit - no YARD return type given, using untyped
     def schedule: (untyped journey) -> untyped
 
-    class RunSchedulingCycleJob < ActiveJob::Base
+    class RunSchedulingCycleJob < StepperMotor::BaseJob
       # sord omit - no YARD return type given, using untyped
       def perform: () -> untyped
     end
   end
 
-  class HousekeepingJob < ActiveJob::Base
+  class HousekeepingJob < StepperMotor::BaseJob
     # sord omit - no YARD return type given, using untyped
     def perform: () -> untyped
   end
 
-  class PerformStepJob < ActiveJob::Base
+  class PerformStepJob < StepperMotor::BaseJob
     # sord omit - no YARD type given for "*posargs", using untyped
     # sord omit - no YARD type given for "**kwargs", using untyped
     # sord omit - no YARD return type given, using untyped
@@ -407,7 +410,7 @@ module StepperMotor
   # `performing` state for far longer than the journey is supposed to. At the moment it assumes
   # any journey that stayed in `performing` for longer than 1 hour has hung. Add this job to your
   # cron table and perform it regularly.
-  class RecoverStuckJourneysJob < ActiveJob::Base
+  class RecoverStuckJourneysJob < StepperMotor::BaseJob
     DEFAULT_STUCK_FOR: untyped
 
     # sord omit - no YARD type given for "stuck_for:", using untyped
@@ -417,7 +420,7 @@ module StepperMotor
 
   # The purpose of this job is to find journeys which have completed (finished or canceled) some
   # time ago and to delete them. The time is configured in the initializer.
-  class DeleteCompletedJourneysJob < ActiveJob::Base
+  class DeleteCompletedJourneysJob < StepperMotor::BaseJob
     # sord omit - no YARD type given for "completed_for:", using untyped
     # sord omit - no YARD return type given, using untyped
     def perform: (?completed_for: untyped) -> untyped

--- a/test/dummy/config/initializers/stepper_motor.rb
+++ b/test/dummy/config/initializers/stepper_motor.rb
@@ -30,3 +30,11 @@ StepperMotor.scheduler = StepperMotor::ForwardScheduler.new
 #     schedule: "*/30 * * * *" # Every 30 minutes
 #     class: "StepperMotor::HousekeepingJob"
 StepperMotor.delete_completed_journeys_after = 30.days
+
+# Extends the base StepperMotor ActiveJob with any calls you would use to customise a
+# job in your codebase. At the minimum, we recommend setting all StepperMotor job priorities
+# to "high" - according to the priority denomination you are using.
+# StepperMotor.extend_base_job do
+#   priority :high
+#   discard_on ActiveRecord::NotFound
+# end

--- a/test/stepper_motor/configuration_test.rb
+++ b/test/stepper_motor/configuration_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class ConfigurationTest < ActiveSupport::TestCase
+  test "allows extending the base job" do
+    retrieved_name = StepperMotor.extend_base_job { name }
+    assert_equal "StepperMotor::BaseJob", retrieved_name
+  end
+end


### PR DESCRIPTION
For example, setting priority can be important, as well as including modules.